### PR TITLE
fix(patternlab): Fix child patterns not loading in Patternlab

### DIFF
--- a/generators/templates/options/ds/copy/patternlab-config.json
+++ b/generators/templates/options/ds/copy/patternlab-config.json
@@ -53,16 +53,16 @@
       "maps": "./dist/maps"
     },
     "public": {
-      "root": "public/",
-      "patterns": "public/components/",
-      "data": "public/styleguide/data/",
-      "annotations": "public/annotations/",
-      "styleguide": "public/styleguide/",
-      "js": "public/components",
-      "images": "public/images",
-      "fonts": "public/fonts",
-      "css": "public/components",
-      "maps": "public/maps"
+      "root": "dist/public/",
+      "patterns": "dist/public/patterns/",
+      "data": "dist/public/styleguide/data/",
+      "annotations": "dist/public/annotations/",
+      "styleguide": "dist/public/styleguide/",
+      "js": "dist/public/components",
+      "images": "dist/public/images",
+      "fonts": "dist/public/fonts",
+      "css": "dist/public/components",
+      "maps": "dist/public/maps"
     }
   },
   "patternExtension": "twig",


### PR DESCRIPTION
1. Renamed the public path for patterns from `dist/public/components/` to `dist/public/patterns/`. It is probably a bug in Patternlab that causes it to look into the `patterns` directory only even when we have a custom named directory.
2. Moved code from root public directory to `dist/public` as generated assets.